### PR TITLE
Change default port to 8100

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install dependencies and run the API:
 
 ```bash
 pip install -r backend/requirements.txt
-uvicorn app.main:app --reload --app-dir backend/app
+uvicorn app.main:app --reload --app-dir backend/app --port 8100
 ```
 
 ## Frontend

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,4 +14,4 @@ async def root():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8100, reload=True)

--- a/backend/systemd/btrfs-ui.service
+++ b/backend/systemd/btrfs-ui.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=YOURUSER
 WorkingDirectory=/path/to/backend
-ExecStart=/usr/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000
+ExecStart=/usr/bin/uvicorn app.main:app --host 0.0.0.0 --port 8100
 Restart=on-failure
 
 [Install]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8000/api',
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8100/api',
   timeout: 5000,
 })

--- a/frontend/src/components/VolumeCard.tsx
+++ b/frontend/src/components/VolumeCard.tsx
@@ -1,4 +1,4 @@
-import { Device, Volume } from '../types'
+import { Volume } from '../types'
 import { StatusBadge } from './StatusBadge'
 
 export function VolumeCard({ volume }: { volume: Volume }) {


### PR DESCRIPTION
## Summary
- change default server port to 8100 in backend and systemd unit
- update frontend API base URL
- fix unused `Device` import to satisfy linter
- document using `--port 8100` when launching uvicorn

## Testing
- `python -m compileall backend/app app.py`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c26193fa8832a82ad0681e88587ea